### PR TITLE
Фикс создания нового материала из импорта

### DIFF
--- a/cfi.php
+++ b/cfi.php
@@ -430,6 +430,9 @@ class plgSystemCfi extends CMSPlugin
                 $inserts++;
             }
 
+            // reload article from model
+	        $article = (array) $model->getItem();
+
             // get article custom fields
             $jsFields = FieldsHelper::getFields('com_content.article', $article, true);
             foreach($jsFields as $key => $jsField) {


### PR DESCRIPTION
При добавлении нового материала на сайт, через импорт, не записываются значения доп.полей.
Связано это с тем, что, после вызова метода save()  https://github.com/AlekVolsk/cfi/blob/d3c8763434f831cfc60ef1456b223240818b67c0/cfi.php#L420 мы не получаем id материала (он остаётся равен 0)
А потом пытаемся сохранить значения полей в материал 0 https://github.com/AlekVolsk/cfi/blob/d3c8763434f831cfc60ef1456b223240818b67c0/cfi.php#L450

Для того, чтобы материал удачно сохранился, нужно, после save() получить только что сохранённый материал обратно


